### PR TITLE
fix: floorページのレイアウトを修正

### DIFF
--- a/src/app/routes/app/floor.tsx
+++ b/src/app/routes/app/floor.tsx
@@ -70,7 +70,7 @@ const Floor = () => {
       style={{ backgroundImage: `url(${floorData.background})` }}
     >
       {/* ヘッダー */}
-      <header className="flex items-center justify-between px-6 pt-8 text-2xl text-white">
+      <header className="z-10 flex items-center justify-between px-6 pt-8 text-2xl text-white relative">
         <button
           className="flex items-center gap-3 rounded-full px-5 py-3"
           onClick={() => navigate(-1)}
@@ -91,12 +91,18 @@ const Floor = () => {
       <FloorMap />
 
       {/* キャラクターとダイアログ */}
-      <div className="absolute bottom-0 left-0 w-full">
-        <img src={character} alt="エコ" className="h-auto w-[370px] mx-auto" />
-        <DialogBubble
-          name="エコ"
-          message={`はじめまして！<br>ECCダンジョンの案内係を担当するエコだよ！<br>今日はよろしくね。`}
-        />
+      <div className="absolute bottom-0 left-0 z-0 size-full">
+        <div className="flex h-full flex-col justify-end">
+          <img
+            src={character}
+            alt="エコ"
+            className="mx-auto h-auto w-[370px]"
+          />
+          <DialogBubble
+            name="エコ"
+            message={`はじめまして！<br>ECCダンジョンの案内係を担当するエコだよ！<br>今日はよろしくね。`}
+          />
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
# 概要

floorページのヘッダーとキャラクター・ダイアログのレイアウトを修正し、z-indexとフレックスボックスを使用して適切な配置を実現しました。

## 変更点

### ヘッダーの修正
- `z-10`と`relative`を追加してz-indexを設定
- 他の要素との重なり順を明確化

### キャラクターとダイアログの配置修正
- コンテナに`z-0`と`size-full`を追加
- フレックスボックスレイアウトを導入（`flex h-full flex-col justify-end`）
- キャラクターとダイアログを画面下部に適切に配置

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>