### PR TITLE
feat: QRコード読み取りボタンのスタイルを改善

### DIFF
--- a/src/feature/map/components/reader-button.tsx
+++ b/src/feature/map/components/reader-button.tsx
@@ -11,7 +11,7 @@ const ReaderButton: React.FC<ButtonHTMLAttributes<HTMLButtonElement>> = ({
       {...props}
       className="flex h-16 w-52 items-center justify-center rounded-2xl bg-gradient-to-b from-[#E9D169] to-[#9C6C4C]"
     >
-      <div className="flex h-14 w-[200px] items-center justify-center space-x-2 rounded-xl bg-[#B9B9BA]">
+      <div className="mx-2 flex h-14 w-full items-center justify-center rounded-xl">
         <MdOutlineQrCodeScanner className="text-5xl" />
         <p className="text-xs font-bold">QRコードを読み取る</p>
       </div>


### PR DESCRIPTION
# 概要

QRコード読み取りボタンの内部スタイルを改善し、視認性を向上させました。

## 変更点

- 固定幅（`w-[200px]`）から可変幅（`w-full`）に変更
- 背景色（`bg-[#B9B9BA]`）を削除してグラデーション背景を活用
- 左右にマージン（`mx-2`）を追加して適切な余白を確保

これにより、ボタンの見た目がすっきりし、グラデーション背景がより目立つようになりました。

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>