### PR TITLE
fix: clearCountが0の場合はQRコードのかけらを非表示に

### DIFF
--- a/src/app/routes/app/get-qr.tsx
+++ b/src/app/routes/app/get-qr.tsx
@@ -132,7 +132,9 @@ export const GetQrRoute = () => {
                 <p>QRコードのかけらを</p>
                 <p>ゲットした!</p>
               </div>
-              <QrPiece pieceId={clearCount} className="my-12" />
+              {clearCount > 0 && (
+                <QrPiece pieceId={clearCount} className="my-12" />
+              )}
               <div className="text-center font-sans text-xl leading-loose font-semibold text-white">
                 <p>鍵が完成するまで</p>
                 <p>


### PR DESCRIPTION
# 概要

clearCountが0の場合にQRコードのかけらが表示されてしまう問題を修正しました。

## 変更点

- `QrPiece` コンポーネントを条件付きレンダリングに変更
- `clearCount > 0` の場合のみQRコードのかけらを表示
- clearCountが0の場合は何も表示しない

これにより、初回表示時やクリアしていない状態で不要なQRコードのかけらが表示されることを防ぎます。

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>